### PR TITLE
bugfix: Modify merge and move algorithm

### DIFF
--- a/src/2048.c
+++ b/src/2048.c
@@ -58,19 +58,19 @@ void play_2048() {
   // キーの入力判定
   while (1) {
     if ((*key & KEY_UP) == KEY_NULL) {
-      swipe(0);
+      swipe(DIRECTION_UP);
       while ((*key & KEY_UP) != KEY_UP)
         ;
     } else if ((*key & KEY_LEFT) == KEY_NULL) {
-      swipe(1);
+      swipe(DIRECTION_LEFT);
       while ((*key & KEY_LEFT) != KEY_LEFT)
         ;
     } else if ((*key & KEY_DOWN) == KEY_NULL) {
-      swipe(2);
+      swipe(DIRECTION_DOWN);
       while ((*key & KEY_DOWN) != KEY_DOWN)
         ;
     } else if ((*key & KEY_RIGHT) == KEY_NULL) {
-      swipe(3);
+      swipe(DIRECTION_RIGHT);
       while ((*key & KEY_RIGHT) != KEY_RIGHT)
         ;
     } else if ((*key & KEY_SELECT) == KEY_NULL) {
@@ -304,7 +304,7 @@ void swipe(hword direction) {
 void merge_number(hword direction, hword n) {
   hword i, j;
   switch (direction) {
-    case 0: {
+    case DIRECTION_UP: {
       for (i = 0; i < 3; i++) {
         if (board[i][n] != 0) {
           for (j = i + 1; j < 4; j++) {
@@ -323,7 +323,7 @@ void merge_number(hword direction, hword n) {
       }
       break;
     }
-    case 1: {
+    case DIRECTION_LEFT: {
       for (i = 0; i < 3; i++) {
         if (board[n][i] != 0) {
           for (j = i + 1; j < 4; j++) {
@@ -342,44 +342,50 @@ void merge_number(hword direction, hword n) {
       }
       break;
     }
-    // case 2: {
-    //   for (i = 3; i >= 1; i--) {
-    //     if (board[i][n] != 0) {
-    //       for (j = i - 1; j >= 0; j--) {
-    //         if (board[i][n] != board[j][n] && board[j][n] != 0) {
-    //           break;
-    //         }
-    //         if (board[i][n] == board[j][n]) {
-    //           board[i][n] *= 2;
-    //           board_flag[i][n] = 1;
-    //           board[j][n] = 0;
-    //           board_flag[j][n] = 1;
-    //           break;
-    //         }
-    //       }
-    //     }
-    //   }
-    //   break;
-    // }
-    // case 3: {
-    //   for (i = 3; i >= 1; i--) {
-    //     if (board[n][i] != 0) {
-    //       for (j = i - 1; j >= 0; j--) {
-    //         if (board[n][i] != board[n][j] && board[n][j] != 0) {
-    //           break;
-    //         }
-    //         if (board[n][i] == board[n][j]) {
-    //           board[n][i] *= 2;
-    //           board_flag[n][i] = 1;
-    //           board[n][j] = 0;
-    //           board_flag[n][j] = 1;
-    //           break;
-    //         }
-    //       }
-    //     }
-    //   }
-    //   break;
-    // }
+    case DIRECTION_DOWN: {
+      for (i = 3; i >= 1; i--) {
+        if (board[i][n] != 0) {
+          for (j = i - 1; j >= 0; j--) {
+            if (board[i][n] != board[j][n] && board[j][n] != 0) {
+              break;
+            }
+            if (board[i][n] == board[j][n]) {
+              board[i][n] *= 2;
+              board_flag[i][n] = 1;
+              board[j][n] = 0;
+              board_flag[j][n] = 1;
+              break;
+            }
+            if(j == 0){ // オーバーフローに対処
+              break;
+            }
+          }
+        }
+      }
+      break;
+    }
+    case DIRECTION_RIGHT: {
+      for (i = 3; i >= 1; i--) {
+        if (board[n][i] != 0) {
+          for (j = i - 1; j >= 0; j--) {
+            if (board[n][i] != board[n][j] && board[n][j] != 0) {
+              break;
+            }
+            if (board[n][i] == board[n][j]) {
+              board[n][i] *= 2;
+              board_flag[n][i] = 1;
+              board[n][j] = 0;
+              board_flag[n][j] = 1;
+              break;
+            }
+            if(j == 0){ // オーバーフローに対処
+              break;
+            }
+          }
+        }
+      }
+      break;
+    }
     default:
       break;
   }
@@ -388,7 +394,7 @@ void merge_number(hword direction, hword n) {
 void move_number(hword direction, hword n) {
   hword i, j;
   switch (direction) {
-    case 0: {
+    case DIRECTION_UP: {
       for (i = 0; i < 3; i++) {
         if (board[i][n] == 0) {
           for (j = i + 1; j < 4; j++) {
@@ -404,7 +410,7 @@ void move_number(hword direction, hword n) {
       }
       break;
     }
-    case 1: {
+    case DIRECTION_LEFT: {
       for (i = 0; i < 3; i++) {
         if (board[n][i] == 0) {
           for (j = i + 1; j < 4; j++) {
@@ -420,38 +426,44 @@ void move_number(hword direction, hword n) {
       }
       break;
     }
-    // case 2: {
-    //   for (i = 3; i >= 1; i--) {
-    //     if (board[i][n] == 0) {
-    //       for (j = i - 1; j >= 0; j--) {
-    //         if (board[j][n] != 0) {
-    //           board[i][n] = board[j][n];
-    //           board_flag[i][n] = 1;
-    //           board[j][n] = 0;
-    //           board_flag[j][n] = 1;
-    //           break;
-    //         }
-    //       }
-    //     }
-    //   }
-    //   break;
-    // }
-    // case 3: {
-    //   for (i = 3; i >= 1; i--) {
-    //     if (board[n][i] == 0) {
-    //       for (j = i - 1; j >= 0; j--) {
-    //         if (board[n][j] != 0) {
-    //           board[n][i] = board[n][j];
-    //           board_flag[n][i] = 1;
-    //           board[n][j] = 0;
-    //           board_flag[n][j] = 1;
-    //           break;
-    //         }
-    //       }
-    //     }
-    //   }
-    //   break;
-    // }
+    case DIRECTION_DOWN: {
+      for (i = 3; i >= 1; i--) {
+        if (board[i][n] == 0) {
+          for (j = i - 1; j >= 0; j--) {
+            if (board[j][n] != 0) {
+              board[i][n] = board[j][n];
+              board_flag[i][n] = 1;
+              board[j][n] = 0;
+              board_flag[j][n] = 1;
+              break;
+            }
+            if(j == 0){ // オーバーフローに対処
+              break;
+            }
+          }
+        }
+      }
+      break;
+    }
+    case DIRECTION_RIGHT: {
+      for (i = 3; i >= 1; i--) {
+        if (board[n][i] == 0) {
+          for (j = i - 1; j >= 0; j--) {
+            if (board[n][j] != 0) {
+              board[n][i] = board[n][j];
+              board_flag[n][i] = 1;
+              board[n][j] = 0;
+              board_flag[n][j] = 1;
+              break;
+            }
+            if(j == 0){ // オーバーフローに対処
+              break;
+            }
+          }
+        }
+      }
+      break;
+    }
     default: {
       break;
     }

--- a/src/2048.h
+++ b/src/2048.h
@@ -26,6 +26,11 @@ typedef volatile unsigned short hword;
 #define KEY_R 0x0100
 #define KEY_L 0x0200
 
+#define DIRECTION_UP 0
+#define DIRECTION_LEFT 1
+#define DIRECTION_DOWN 2
+#define DIRECTION_RIGHT 3
+
 #define WINDOW_X 240
 #define WINDOW_Y 160
 


### PR DESCRIPTION
## 右と下に動かせないバグの修正

### バグの詳細

+ 右にスワイプすると，数字がおかしくなり，その後の動作がおかしくなる
+ 下にスワイプすると，数字がおかしくなり，その後キー操作を受け付けなくなる

### 修正内容

+ `merge_number`関数と`move_number`関数の修正
+ 移動方向のマジックナンバーをdefine宣言
  + 形式は`DIRECTION_XX`

### バグの原因

原因は，**オーバーフロー**と**配列の範囲外アクセス**．

4\*4の盤面をforループするときの添字管理に抜けがあった．

問題となる箇所のうち一つを挙げる．

https://github.com/Riki-Okunishi/isd-exp1-3/blob/892b2463955b403eba033d2b714bb557dc7d3e35/src/2048.c#L345-L363

ここでの変数`j`は，forループが回る中で，`j=0`のときにデクリメントされてしまう．
`j`は`unsigned short`なので，オーバーフローして恐らく`65535`になってしまったと考えられる．
そのまま`board[j][n]`などの変数にアクセスしようとし，範囲外アクセスしてしまったようだ．
`j >= 0`の条件式は常に`true`になるので，forの条件式を変えても良かったが，アルゴリズム的に代替案が分からなかったので`break`文で対応した．

右のときにプログラムの実行が続くのは，範囲外参照を続けたのちに盤面の"他の列"を参照して，forを`break`できるからだと思われる．反応がやけに遅くなるので多分そう．
下のときにフリーズするのはよくわからん:innocent:．アクセスしてはいけない領域でも参照してるんちゃう，しらんけど．

